### PR TITLE
Make a library application that works in erlang.mk

### DIFF
--- a/src/eraven.app.src
+++ b/src/eraven.app.src
@@ -11,8 +11,6 @@
   {env,[]},
   {modules, []},
 
-  {mod, {eraven, []}},
-
   {maintainers, ["Boris Murashov <bottleneko@gmail.com>"]},
   {licenses, ["MIT"]},
   {links, []}


### PR DESCRIPTION
(At least when using erlang.mk)...:

Specifying the `mod` here leads to Erlang attempting to `eraven:start()`, although there is no `start` defined, thus failing. Removing this allows eraven to be used in erlang.mk