### PR TITLE
er_dsn: Replace depracted http_uri call to parse

### DIFF
--- a/src/er_dsn.erl
+++ b/src/er_dsn.erl
@@ -23,8 +23,13 @@
     DsnString :: string(),
     Reason    :: term().
 new(DsnString) when is_list(DsnString) ->
-  case http_uri:parse(DsnString) of
-    {ok, {Scheme, UserInfo, Hostname, Port, Path, _Qs}} ->
+  case uri_string:parse(DsnString) of
+    #{scheme := Scheme, userinfo := UserInfo, host := Hostname, path := Path} = URIMap ->
+      DefaultPort = case Scheme of
+        "http" -> 80;
+        "https" -> 443
+      end,
+      Port = maps:get(port, URIMap, DefaultPort),
       {PublicKey, SecretKey} = parse_keys(UserInfo),
       Dsn =
         #er_dsn{


### PR DESCRIPTION
http_uri was deprecated in OTP21 and removed in OTP25

Closes #6 